### PR TITLE
Add SecureStringStore & Keychain

### DIFF
--- a/App/App.xcodeproj/project.pbxproj
+++ b/App/App.xcodeproj/project.pbxproj
@@ -13,6 +13,8 @@
 		912A14F521B0ACD200422DE4 /* UINavigationControllerPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912A14F421B0ACD200422DE4 /* UINavigationControllerPresenterTests.swift */; };
 		91533D7B21B09C4000CE722A /* CommonUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 91533D7921B09C3C00CE722A /* CommonUI.framework */; };
 		91533D7C21B09C4000CE722A /* CommonUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 91533D7921B09C3C00CE722A /* CommonUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		9176866721BB1D4500DE897B /* Common.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9176866221BB1D2A00DE897B /* Common.framework */; };
+		9176866821BB1D4500DE897B /* Common.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9176866221BB1D2A00DE897B /* Common.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		917AAB3821B0AFED004C392F /* AppCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917AAB3721B0AFED004C392F /* AppCoordinator.swift */; };
 		918E081F21B03AC100FB90D7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918E081E21B03AC100FB90D7 /* AppDelegate.swift */; };
 		918E082621B03AC100FB90D7 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 918E082521B03AC100FB90D7 /* Assets.xcassets */; };
@@ -41,6 +43,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				91A460AD21B3270F00799C52 /* PlaygroundBrowserUI.framework in Embed Frameworks */,
+				9176866821BB1D4500DE897B /* Common.framework in Embed Frameworks */,
 				9124FC9221B8052D00844300 /* Playground.framework in Embed Frameworks */,
 				91533D7C21B09C4000CE722A /* CommonUI.framework in Embed Frameworks */,
 			);
@@ -54,6 +57,7 @@
 		912A14E421B0A93300422DE4 /* UINavigationController+Presenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Presenter.swift"; sourceTree = "<group>"; };
 		912A14F421B0ACD200422DE4 /* UINavigationControllerPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UINavigationControllerPresenterTests.swift; sourceTree = "<group>"; };
 		91533D7921B09C3C00CE722A /* CommonUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CommonUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		9176866221BB1D2A00DE897B /* Common.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Common.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		917AAB3721B0AFED004C392F /* AppCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppCoordinator.swift; sourceTree = "<group>"; };
 		918E081B21B03AC100FB90D7 /* App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = App.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		918E081E21B03AC100FB90D7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -73,6 +77,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9124FC9121B8052D00844300 /* Playground.framework in Frameworks */,
+				9176866721BB1D4500DE897B /* Common.framework in Frameworks */,
 				91A460AC21B3270F00799C52 /* PlaygroundBrowserUI.framework in Frameworks */,
 				91533D7B21B09C4000CE722A /* CommonUI.framework in Frameworks */,
 			);
@@ -107,6 +112,7 @@
 		91533D7821B09C3C00CE722A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				9176866221BB1D2A00DE897B /* Common.framework */,
 				9124FC8F21B8051F00844300 /* Playground.framework */,
 				91A460AA21B3270800799C52 /* PlaygroundBrowserUI.framework */,
 				91533D7921B09C3C00CE722A /* CommonUI.framework */,

--- a/App/App/AppDelegate.swift
+++ b/App/App/AppDelegate.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Common
 import CommonUI
 
 final class AppDelegate: UIResponder {
@@ -7,7 +8,9 @@ final class AppDelegate: UIResponder {
 		return navigationController
 	}()
 
-	private lazy var coordinator: Coordinator = AppCoordinator(presenter: presenter)
+	private var keychain: SecureStringStore = Keychain()
+
+	private lazy var coordinator: Coordinator = AppCoordinator(presenter: presenter, secureStringStore: &keychain)
 
 	lazy var window: UIWindow? = {
 		let window = UIWindow(frame: UIScreen.main.bounds)

--- a/App/App/Coordinators/AppCoordinator.swift
+++ b/App/App/Coordinators/AppCoordinator.swift
@@ -1,13 +1,16 @@
 import UIKit
+import Common
 import CommonUI
 import PlaygroundBrowserUI
 
 final class AppCoordinator: Coordinator {
 	private let presenter: Presenter
+	private var secureStringStore: SecureStringStore
 	private var children = [Coordinator]()
 
-	init(presenter: Presenter) {
+	init(presenter: Presenter, secureStringStore: inout SecureStringStore) {
 		self.presenter = presenter
+		self.secureStringStore = secureStringStore
 	}
 
 	func start() {

--- a/Common/Common.xcodeproj/project.pbxproj
+++ b/Common/Common.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		3D40B54921B9213200A9115D /* NetworkSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D40B54821B9213200A9115D /* NetworkSession.swift */; };
 		3D40B54B21B9215700A9115D /* URLSession+NetworkSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D40B54A21B9215700A9115D /* URLSession+NetworkSession.swift */; };
 		3D40B55121B921D600A9115D /* URLSessionNetworkSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D40B54E21B921B500A9115D /* URLSessionNetworkSessionTests.swift */; };
+		9176865121BB111200DE897B /* SecureStringStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9176865021BB111200DE897B /* SecureStringStore.swift */; };
+		9176865621BB137B00DE897B /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9176865521BB137B00DE897B /* Keychain.swift */; };
 		9196389721B83ED500275D32 /* Common.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9196388D21B83ED500275D32 /* Common.framework */; };
 		9196389E21B83ED500275D32 /* Common.h in Headers */ = {isa = PBXBuildFile; fileRef = 9196389021B83ED500275D32 /* Common.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
@@ -28,6 +30,8 @@
 		3D40B54821B9213200A9115D /* NetworkSession.swift */ = {isa = PBXFileReference; indentWidth = 2; lastKnownFileType = sourcecode.swift; path = NetworkSession.swift; sourceTree = "<group>"; tabWidth = 2; usesTabs = 1; };
 		3D40B54A21B9215700A9115D /* URLSession+NetworkSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URLSession+NetworkSession.swift"; sourceTree = "<group>"; };
 		3D40B54E21B921B500A9115D /* URLSessionNetworkSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSessionNetworkSessionTests.swift; sourceTree = "<group>"; };
+		9176865021BB111200DE897B /* SecureStringStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecureStringStore.swift; sourceTree = "<group>"; };
+		9176865521BB137B00DE897B /* Keychain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
 		9196388D21B83ED500275D32 /* Common.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Common.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9196389021B83ED500275D32 /* Common.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Common.h; sourceTree = "<group>"; };
 		9196389121B83ED500275D32 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -66,6 +70,8 @@
 			isa = PBXGroup;
 			children = (
 				3D40B54821B9213200A9115D /* NetworkSession.swift */,
+				9176865021BB111200DE897B /* SecureStringStore.swift */,
+				9176865521BB137B00DE897B /* Keychain.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -226,7 +232,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				3D40B54B21B9215700A9115D /* URLSession+NetworkSession.swift in Sources */,
+				9176865621BB137B00DE897B /* Keychain.swift in Sources */,
 				3D40B54921B9213200A9115D /* NetworkSession.swift in Sources */,
+				9176865121BB111200DE897B /* SecureStringStore.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Common/Common/Types/Keychain.swift
+++ b/Common/Common/Types/Keychain.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+public struct Keychain: SecureStringStore {
+	private let syncsWithICloud: Bool
+	private let searchQuery: CFDictionary
+
+	public init(syncingWithICloud: Bool = true) {
+		self.syncsWithICloud = syncingWithICloud
+		let searchQuery: [String: Any] = [
+			kSecClassKey as String: kSecClassGenericPassword,
+			kSecAttrSynchronizable as String: syncsWithICloud,
+			kSecReturnData as String: true
+		]
+		self.searchQuery = searchQuery as CFDictionary
+	}
+
+	public subscript(key: String) -> String? {
+		get {
+			return value(for: key)
+		} set (newValue) {
+			set(newValue, for: key)
+		}
+	}
+
+	private func value(for key: String) -> String? {
+		var item: CFTypeRef?
+		_ = SecItemCopyMatching(searchQuery, &item)
+		if let data = item as? Data, let value = String(data: data, encoding: .utf8) {
+			return value
+		} else {
+			return nil
+		}
+	}
+
+	private func set(_ value: String?, for key: String) {
+		if let value = value, let data = value.data(using: .utf8) {
+			let query: [String: Any] = [
+				kSecClassKey as String: kSecClassGenericPassword,
+				kSecAttrSynchronizable as String: syncsWithICloud,
+				kSecValueData as String: data
+			]
+			let status = SecItemAdd(query as CFDictionary, nil)
+			print(status)
+		} else {
+			SecItemDelete(searchQuery)
+		}
+	}
+}

--- a/Common/Common/Types/Keychain.swift
+++ b/Common/Common/Types/Keychain.swift
@@ -1,14 +1,14 @@
 import Foundation
 
+/// `SecureStringStore` based on Keychain.
 public struct Keychain: SecureStringStore {
-	private let syncsWithICloud: Bool
 	private let searchQuery: CFDictionary
 
-	public init(syncingWithICloud: Bool = true) {
-		self.syncsWithICloud = syncingWithICloud
+	/// Create a new `Keychain` instance.
+	public init() {
 		let searchQuery: [String: Any] = [
 			kSecClassKey as String: kSecClassGenericPassword,
-			kSecAttrSynchronizable as String: syncsWithICloud,
+			kSecAttrSynchronizable as String: true,
 			kSecReturnData as String: true
 		]
 		self.searchQuery = searchQuery as CFDictionary
@@ -36,7 +36,7 @@ public struct Keychain: SecureStringStore {
 		if let value = value, let data = value.data(using: .utf8) {
 			let query: [String: Any] = [
 				kSecClassKey as String: kSecClassGenericPassword,
-				kSecAttrSynchronizable as String: syncsWithICloud,
+				kSecAttrSynchronizable as String: true,
 				kSecValueData as String: data
 			]
 			let status = SecItemAdd(query as CFDictionary, nil)

--- a/Common/Common/Types/SecureStringStore.swift
+++ b/Common/Common/Types/SecureStringStore.swift
@@ -1,0 +1,4 @@
+/// Implementing types provide a secure storage for strings.
+public protocol SecureStringStore {
+	subscript(key: String) -> String? { get set }
+}

--- a/Feature/Playground/PlaygroundTests/Models/PlaygroundTemplateTests.swift
+++ b/Feature/Playground/PlaygroundTests/Models/PlaygroundTemplateTests.swift
@@ -8,5 +8,6 @@ final class PlaygroundTemplateTests: XCTestCase {
 
 		XCTAssertEqual(template.settings, Playground.Settings(endpoint: endpoint))
 		XCTAssertEqual(template.contents, "\n")
+		XCTAssertEqual(template.name, "GitHub")
 	}
 }


### PR DESCRIPTION
This PR is the first step towards closing #23. 

`SecureStringStore` is a protocol-based abstraction for a *secure string store*, whereas `Keychain` is an implementation of it using the iOS Keychain. When storing strings with `Keychain` they'll be automatically synced via iCloud if the user has *iCloud Keychain* enabled.